### PR TITLE
fix: resolve 36 SonarCloud issues

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -70,7 +70,7 @@ jobs:
           /k:"slipalison_Responses"
           /o:"slipalison"
           /d:sonar.host.url="https://sonarcloud.io"
-          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.token="$env:SONAR_TOKEN"
           /d:sonar.cs.opencover.reportsPaths="test/Responses.Tests/coverage/coverage.opencover.xml"
 
       - name: Build
@@ -95,10 +95,10 @@ jobs:
       - name: SonarQube end
         if: env.SONAR_TOKEN != ''
         shell: powershell
-        run: .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        run: .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5975040f7f7d40edaff8d784b576fd65ae95c073 # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: test/Responses.Tests/coverage/coverage.info
@@ -125,8 +125,10 @@ jobs:
       # --skip-duplicate makes re-publishing an existing version a no-op,
       # replacing the old "publish on version change" behavior.
       - name: Push to NuGet
+        env:
+          NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
         run: >
           dotnet nuget push "./artifacts/*.nupkg"
-          --api-key "${{ secrets.NUGET_TOKEN }}"
+          --api-key "$NUGET_TOKEN"
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate

--- a/benchmarks/Responses.Benchmarks/AllocationBenchmarks.cs
+++ b/benchmarks/Responses.Benchmarks/AllocationBenchmarks.cs
@@ -8,7 +8,6 @@ namespace Responses.Benchmarks;
 /// </summary>
 public class ResultAllocationBenchmarks
 {
-    private static readonly Error _error = Error.Validation("ERR", "message");
     private static readonly Func<int, int> _mapFunc = x => x * 2;
     private static readonly Func<int, Result<int>> _bindFunc = x => Result.Ok(x * 2);
 

--- a/benchmarks/Responses.Benchmarks/Responses.Benchmarks.csproj
+++ b/benchmarks/Responses.Benchmarks/Responses.Benchmarks.csproj
@@ -8,6 +8,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet requires [Benchmark] methods to be public instance methods,
+         so CA1822 (members can be marked static) is a false positive for this project. -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Responses.Tests/ErrorModelTests.cs
+++ b/test/Responses.Tests/ErrorModelTests.cs
@@ -13,16 +13,16 @@ public class ErrorModelTests
         [Fact]
         public void ErrorType_HasAllExpectedValues()
         {
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Unknown));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Validation));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.NotFound));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Conflict));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Unauthorized));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Forbidden));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.ServerError));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Timeout));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.Cancelled));
-            Assert.True(Enum.IsDefined(typeof(ErrorType), ErrorType.InternalError));
+            Assert.True(Enum.IsDefined(ErrorType.Unknown));
+            Assert.True(Enum.IsDefined(ErrorType.Validation));
+            Assert.True(Enum.IsDefined(ErrorType.NotFound));
+            Assert.True(Enum.IsDefined(ErrorType.Conflict));
+            Assert.True(Enum.IsDefined(ErrorType.Unauthorized));
+            Assert.True(Enum.IsDefined(ErrorType.Forbidden));
+            Assert.True(Enum.IsDefined(ErrorType.ServerError));
+            Assert.True(Enum.IsDefined(ErrorType.Timeout));
+            Assert.True(Enum.IsDefined(ErrorType.Cancelled));
+            Assert.True(Enum.IsDefined(ErrorType.InternalError));
         }
 
         [Fact]
@@ -148,10 +148,12 @@ public class ErrorModelTests
         [Fact]
         public void Error_ImplementsIError()
         {
-            IError error = new Error("ERR", "msg", ErrorType.Validation);
-            Assert.Equal("ERR", error.Code);
-            Assert.Equal("msg", error.Message);
-            Assert.Equal(ErrorType.Validation, error.Type);
+            var error = new Error("ERR", "msg", ErrorType.Validation);
+
+            var contract = Assert.IsAssignableFrom<IError>(error);
+            Assert.Equal("ERR", contract.Code);
+            Assert.Equal("msg", contract.Message);
+            Assert.Equal(ErrorType.Validation, contract.Type);
         }
     }
 

--- a/test/Responses.Tests/FunctionalCompositionTests.cs
+++ b/test/Responses.Tests/FunctionalCompositionTests.cs
@@ -342,7 +342,7 @@ public class FunctionalCompositionTests
         {
             var result = Result.Ok("hello@example.com")
                 .Ensure(s => !string.IsNullOrEmpty(s), new Error("EMPTY", "required"))
-                .Ensure(s => s.Contains("@"), new Error("FMT", "invalid format"))
+                .Ensure(s => s.Contains('@'), new Error("FMT", "invalid format"))
                 .Ensure(s => s.Length >= 5, new Error("LEN", "too short"));
             Assert.True(result.IsSuccess);
         }
@@ -352,7 +352,7 @@ public class FunctionalCompositionTests
         {
             var result = Result.Ok("x")
                 .Ensure(s => !string.IsNullOrEmpty(s), new Error("EMPTY", "required"))
-                .Ensure(s => s.Contains("@"), new Error("FMT", "invalid format"))
+                .Ensure(s => s.Contains('@'), new Error("FMT", "invalid format"))
                 .Ensure(s => s.Length >= 5, new Error("LEN", "too short"));
             Assert.False(result.IsSuccess);
             Assert.Equal("FMT", result.Error.Code);

--- a/test/Responses.Tests/HttpExtensionsTests.cs
+++ b/test/Responses.Tests/HttpExtensionsTests.cs
@@ -270,12 +270,14 @@ public class HttpExtensionsTests
 
     public class HttpResponseInfoTests
     {
+        private static readonly string[] JsonContentType = ["application/json"];
+
         [Fact]
         public void HttpResponseInfo_CreatesWithAllProperties()
         {
             var headers = new Dictionary<string, IEnumerable<string>>
             {
-                { "Content-Type", new[] { "application/json" } }
+                { "Content-Type", JsonContentType }
             };
             var info = new HttpResponseInfo(
                 System.Net.HttpStatusCode.OK,

--- a/test/Responses.Tests/LinqSupportTests.cs
+++ b/test/Responses.Tests/LinqSupportTests.cs
@@ -198,7 +198,7 @@ public class LinqSupportTests
             var query = from input in Result.Ok("  test@example.com  ")
                         let trimmed = input.Trim()
                         from validated in Result.Ok(trimmed).Ensure(
-                            s => s.Contains("@"),
+                            s => s.Contains('@'),
                             new Error("INVALID", "not an email"))
                         select validated.ToUpper();
 
@@ -212,7 +212,7 @@ public class LinqSupportTests
             var query = from input in Result.Ok("invalid")
                         let trimmed = input.Trim()
                         from validated in Result.Ok(trimmed).Ensure(
-                            s => s.Contains("@"),
+                            s => s.Contains('@'),
                             new Error("INVALID", "not an email"))
                         select validated.ToUpper();
 

--- a/test/Responses.Tests/StringRepresentationTests.cs
+++ b/test/Responses.Tests/StringRepresentationTests.cs
@@ -301,8 +301,8 @@ public class StringRepresentationTests
             var email = "not-an-email";
             var result = Result.Ok(email)
                 .Ensure(e => !string.IsNullOrEmpty(e), new Error("EMPTY", "Required"))
-                .Ensure(e => e.Contains("@"), new Error("FORMAT", "Invalid format"))
-                .Ensure(e => e.Contains("."), new Error("DOMAIN", "Missing domain"));
+                .Ensure(e => e.Contains('@'), new Error("FORMAT", "Invalid format"))
+                .Ensure(e => e.Contains('.'), new Error("DOMAIN", "Missing domain"));
 
             Assert.True(result.IsFailed);
             Assert.Equal("FORMAT", result.Error.Code);


### PR DESCRIPTION
## Resumo

Resolve as 36 issues abertas no SonarCloud (`slipalison_Responses`), em 4 commits atômicos.

### Segurança (4 MAJOR) — workflow CI
- **S7636 ×3**: elimina expansão de `${{ secrets.* }}` dentro de blocos `run`. `SONAR_TOKEN` passa pelo `env` de job (lido como `$env:SONAR_TOKEN` nos steps PowerShell); `NUGET_TOKEN` via `env` de step (`$NUGET_TOKEN`).
- **S7637 ×1**: `codecov/codecov-action` fixado no SHA imutável de `v5.5.5` em vez da tag móvel `@v5`.

### Bug real (1 MAJOR)
- **S1144**: campo morto `_error` removido de `AllocationBenchmarks`.

### Code smells (31 INFO)
| Regra | Qtd | Fix |
|---|---|---|
| CA1822 | 13 | `NoWarn` no `.csproj` — `[Benchmark]` exige método de instância (falso-positivo BenchmarkDotNet) |
| CA2263 | 10 | overload genérico `Enum.IsDefined<TEnum>` |
| CA1847 | 6 | overload `string.Contains(char)` |
| CA1859 | 1 | contrato `IError` via `Assert.IsAssignableFrom` (mantém intento, sem local tipado por interface) |
| CA1861 | 1 | array constante içado p/ `static readonly` |

## Verificação
- Build Release: **0 avisos, 0 erros** (4 projetos)
- Testes: **506/506 aprovados**

## Commits
- `ci(security)`: harden secret handling + pin Codecov SHA
- `refactor(benchmarks)`: remove unused `_error` field
- `build(benchmarks)`: suppress CA1822 for BenchmarkDotNet methods
- `test`: resolve SonarCloud code smells in the test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6QxiE6E3LhN8gWxa1ykAL
